### PR TITLE
NOISSUE - View records set in last one hour

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.6-alpine AS builder
+FROM golang:1.21.0-alpine AS builder
 ARG SVC
 ARG GOARCH
 ARG GOARM

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mainflux/callhome
 
-go 1.20
+go 1.21
 
 require (
 	github.com/caarlos0/env/v7 v7.1.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFP
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
+github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/a8m/expect v1.0.0/go.mod h1:4IwSCMumY49ScypDnjNbYEjgVeqy1/U2cEs3Lat96eA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -201,6 +202,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -474,6 +476,7 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -768,6 +771,7 @@ golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
+golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/service.go
+++ b/service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"text/template"
 	"time"
 )
@@ -64,6 +65,10 @@ func (ts *telemetryService) RetrieveSummary(ctx context.Context, filters Telemet
 func (ts *telemetryService) ServeUI(ctx context.Context, filters TelemetryFilters) ([]byte, error) {
 	tmpl := template.Must(template.ParseFiles("./web/template/index.html"))
 
+	if filters.From.IsZero() && filters.To.IsZero() {
+		filters.From = time.Now().Add(-time.Hour)
+	}
+
 	summary, err := ts.repo.RetrieveSummary(ctx, filters)
 	if err != nil {
 		return nil, err
@@ -88,10 +93,12 @@ func (ts *telemetryService) ServeUI(ctx context.Context, filters TelemetryFilter
 
 	var from, to string
 	if !filters.From.IsZero() {
-		from = filters.From.Format(time.DateOnly)
+		from = filters.From.Format(time.RFC3339)
+		from = strings.ReplaceAll(from, "Z", "")
 	}
 	if !filters.To.IsZero() {
-		to = filters.To.Format(time.DateOnly)
+		to = filters.To.Format(time.RFC3339)
+		to = strings.ReplaceAll(to, "Z", "")
 	}
 	data := struct {
 		Countries       string

--- a/timescale/init.go
+++ b/timescale/init.go
@@ -28,6 +28,13 @@ func Migration() migrate.MemoryMigrationSource {
 				},
 				Down: []string{"DROP TABLE telemetry;"},
 			},
+			{
+				Id: "telemetry_2",
+				Up: []string{
+					`SELECT add_retention_policy('telemetry', INTERVAL '90 days');`,
+				},
+				Down: []string{`SELECT remove_retention_policy('telemetry');`},
+			},
 		},
 	}
 }

--- a/web/template/index.html
+++ b/web/template/index.html
@@ -36,9 +36,9 @@
 	                        <div class="mb-3">
                                 <form id="filter-form" onsubmit="applyFilter(event)">
                                     <label for="from-date">From:</label>
-                                    <input type="date" id="from-date" name="from-date" value="{{.From}}">
+                                    <input type="datetime-local" id="from-date" name="from-date" value="{{.From}}">
                                     <label for="to-date">To:</label>
-                                    <input type="date" id="to-date" name="to-date" value="{{.To}}">
+                                    <input type="datetime-local" id="to-date" name="to-date" value="{{.To}}">
                                     <br>
                                     <label for="country-filter" class="form-label">Country</label>
                                     <select id="country-filter" class="form-select">


### PR DESCRIPTION
### What does this do?
- Update Golang version to 1.21
- Set retention policy of 90 days.
- Set default view to show past 1 hour of records.
- Use datetime input for from and to filters rather than just date

### Which issue(s) does this PR fix/relate to?
None

### List any changes that modify/break current functionality

### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes